### PR TITLE
- Give CHECK_DEVICE_INDEX a suitable error message

### DIFF
--- a/src/utilities.h
+++ b/src/utilities.h
@@ -43,7 +43,7 @@ static char errorMessage[512];
 
 #define CHECK_DEVICE_INDEX(param) \
 if (!mxIsNumeric(param) || (mxGetScalar(param) < 0)) \
-    {mexErrMsgTxt("Gain must be numeric");return;}
+    {mexErrMsgTxt("Device Index must be numeric");return;}
 
 #define CHECK_DEVICE_HANDLE(param) \
 char tmp[100]; sprintf(tmp,"%d",*(int**)mxGetPr(param)); \


### PR DESCRIPTION
The error messages of CHECK_DEVICE_INDEX and CHECK_GAIN are the same. I think they should be different.
